### PR TITLE
Fix/adid

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -82,6 +82,7 @@ exports.identify = function(identify){
 function common(facade){
   var options = facade.options('Amplitude');
   var os = facade.proxy('context.os.name');
+  var library = facade.proxy('context.library');
   var ret = {
     user_id: facade.userId(),
     device_id: facade.proxy('context.device.id') || facade.anonymousId(),
@@ -112,14 +113,30 @@ function common(facade){
   if (facade.city()) ret.city = facade.city();
   if (facade.region()) ret.region = facade.region();
 
-  if (os && os.toLowerCase() == 'ios') {
+  function mobileDeviceType(){
+    if (!library && !os) return 'unknown';
+    if (contains('ios')) return 'ios';
+    if (contains('android')) return 'android';
+    return 'unknown';
+
+    function contains(str) {
+      return getField(library).toLowerCase().indexOf(str) !== -1
+          || getField(os).toLowerCase().indexOf(str) !== -1;
+    }
+
+    function getField(field) {
+      return typeof field === 'string' ? field : field.name;
+    }
+ }
+
+  if (mobileDeviceType() === 'ios') {
       ret.idfa = facade.proxy('device.idfa');
-  } else if (os && os.toLowerCase() == 'android') {
-      //Older segment clients sent idfa, newer ones send advertisingId
-      ret.adid = facade.proxy('device.idfa');
-      if(!ret.adid) {
-        ret.adid = facade.proxy('device.advertisingId');
-      }
+  }
+
+  if (mobileDeviceType() === 'android') {
+    //Older segment clients sent idfa, newer ones send advertisingId
+    ret.adid = facade.proxy('device.idfa');
+    if (!ret.adid) ret.adid = facade.proxy('device.advertisingId');
   }
 
   ret.user_properties = traits(facade.traits());

--- a/test/fixtures/track-android.json
+++ b/test/fixtures/track-android.json
@@ -18,7 +18,7 @@
         "idfa": "device-idfa"
       },
       "locale": "en-US",
-      "library": { "name": "analytics-ios" },
+      "library": { "name": "analytics-android" },
       "app": { "version": "app-version" },
       "os": {
         "name": "Android",
@@ -44,7 +44,7 @@
     "session_id": 1,
     "event_id": 1,
     "app_version": "app-version",
-    "platform": "analytics-ios",
+    "platform": "analytics-android",
     "os_name": "Android",
     "os_version": "os-version",
     "device_brand": "device-brand",


### PR DESCRIPTION
The key here is that we're now also checking `context.library`, not just `context.os`, to discern device type. not sure why `os.name` would ever be missing, but have seen it in certain cases. Also, we generally use library over OS in other integrations / at the API level for this.

![](https://cloudup.com/chROxGUukja+)

this exercise also uncovered an issue in a test! (hence second commit, separate for clarity)

@f2prateek @ndhoule 
