### PR TITLE
stringify device.type to avoid uncaught exception

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -123,9 +123,9 @@ function common(facade){
   if (facade.city()) ret.city = facade.city();
   if (facade.region()) ret.region = facade.region();
 
-  if (os && os.toLowerCase() == 'ios') {
+  if (os && os.toString().toLowerCase() == 'ios') {
       ret.idfa = facade.proxy('device.idfa');
-  } else if (os && os.toLowerCase() == 'android') {
+  } else if (os && os.toString().toLowerCase() == 'android') {
       //Older segment clients sent idfa, newer ones send advertisingId
       ret.adid = facade.proxy('device.idfa');
       if (!ret.adid) {
@@ -135,7 +135,7 @@ function common(facade){
 
   var lib = facade.proxy('context.library.name');
   var platform = platformFromLibrary(lib) || facade.proxy('context.device.type') || (os && os.toLowerCase()) || lib;
-  ret.platform = sanitizePlatform(platform);
+  if (platform) ret.platform = sanitizePlatform(platform);
 
   ret.user_properties = traits(facade.traits());
 
@@ -150,7 +150,7 @@ function common(facade){
  */
 function platformFromLibrary(library){
   if (library) {
-    library = library.toLowerCase();
+    library = library.toString().toLowerCase();
     if (library == 'analytics.js') return 'Web';
     if (library == 'analytics-android') return 'Android';
     if (library == 'analytics-ios') return 'iOS';
@@ -166,12 +166,12 @@ function platformFromLibrary(library){
  */
  function sanitizePlatform(platform){
   if (platform) {
-    platform = platform.toLowerCase();
+    platform = platform.toString().toLowerCase();
     if (platform == 'web') return 'Web';
     if (platform == 'android') return 'Android';
     if (platform == 'ios') return 'iOS';
   }
-  return platform;
+  return null;
  }
 
 /**

--- a/test/fixtures/track-bad.json
+++ b/test/fixtures/track-bad.json
@@ -1,0 +1,71 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "country": "United States",
+      "revenue": 19.99,
+      "property": true
+    },
+    "context": {
+      "device": {
+        "id": "device-id",
+        "model": "device-model",
+        "brand": "device-brand",
+        "manufacturer": "device-manufacturer",
+        "type": 1
+      },
+      "locale": "en-US",
+      "library": { "name": 2 },
+      "app": { "version": "app-version" },
+      "os": {
+        "name": "os-name",
+        "version": "os-version"
+      },
+      "network": { "carrier": "carrier" },
+      "ip": "0.0.0.0",
+      "location": {
+        "latitude": 1.0,
+        "longitude": 1.0
+      }
+    },
+    "integrations": {
+      "Amplitude": {
+        "eventType": "amplitude-event-type",
+        "sessionId": 1,
+        "eventId": 1
+      }
+    }
+  },
+  "output": {
+    "amplitude_event_type": "amplitude-event-type",
+    "session_id": 1,
+    "event_id": 1,
+    "app_version": "app-version",
+    "os_name": "os-name",
+    "os_version": "os-version",
+    "device_brand": "device-brand",
+    "carrier": "carrier",
+    "device_id": "device-id",
+    "device_manufacturer": "device-manufacturer",
+    "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
+    "location_lat": 1.0,
+    "location_lng": 1.0,
+    "device_model": "device-model",
+    "user_id": "user-id",
+    "revenue": 19.99,
+    "time": 1388534400000,
+    "event_type": "my-event",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,29 @@ describe('Amplitude', function(){
         .track(json.input)
         .error(done);
     });
+
+    it('should prevent uncaught exceptions for manually sent context properties', function(done){
+      var json = test.fixture('track-bad');
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query('api_key', settings.apiKey)
+        .query('event', json.output, JSON.parse)
+        .expects(200, done);
+    });
+
+    it('should prevent not send platform value if invalid', function(done){
+      var json = test.fixture('track-bad');
+      json.input.context.device.type = 'bogus';
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query('api_key', settings.apiKey)
+        .query('event', json.output, JSON.parse)
+        .expects(200, done);
+    });
   });
 
   describe('.identify()', function(){


### PR DESCRIPTION
This will guard against events where `context.device.type` was manually overwritten with something other than a string.

@segment-integrations/core 