### PR TITLE
default to library if platform invalid

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -171,7 +171,7 @@ function platformFromLibrary(library){
     if (platform == 'android') return 'Android';
     if (platform == 'ios') return 'iOS';
   }
-  return null;
+  return platform;
  }
 
 /**

--- a/test/fixtures/track-analytics-php.json
+++ b/test/fixtures/track-analytics-php.json
@@ -14,14 +14,12 @@
         "id": "device-id",
         "model": "device-model",
         "brand": "device-brand",
-        "manufacturer": "device-manufacturer",
-        "type": 1
+        "manufacturer": "device-manufacturer"
       },
       "locale": "en-US",
-      "library": { "name": 2 },
+      "library": { "name": "analytics-php" },
       "app": { "version": "app-version" },
       "os": {
-        "name": "os-name",
         "version": "os-version"
       },
       "network": { "carrier": "carrier" },
@@ -44,9 +42,8 @@
     "session_id": 1,
     "event_id": 1,
     "app_version": "app-version",
-    "os_name": "os-name",
     "os_version": "os-version",
-    "platform": "1",
+    "platform": "analytics-php",
     "device_brand": "device-brand",
     "carrier": "carrier",
     "device_id": "device-id",

--- a/test/index.js
+++ b/test/index.js
@@ -201,9 +201,8 @@ describe('Amplitude', function(){
         .expects(200, done);
     });
 
-    it('should prevent not send platform value if invalid', function(done){
-      var json = test.fixture('track-bad');
-      json.input.context.device.type = 'bogus';
+    it('should send library value if platform is invalid', function(done){
+      var json = test.fixture('track-analytics-php');
 
       test
         .set(settings)


### PR DESCRIPTION
We recently had a few customers report that `analytics-php` and `Analytics.NET` platform values are now showing up as `null`/`none`. Amplitude officially only supports iOS, Android, and Web, but I think it's valuable to default back to the Segment library if it's not one of those 3. We would rather the platform show `analytics-php` and `Analytics.NET` instead of no value at all.

PTAL @hankim813 