### PR TITLE
map segment group to amplitude identify group

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ Amplitude.prototype.page = track;
 Amplitude.prototype.screen = track;
 Amplitude.prototype.track = track;
 Amplitude.prototype.identify = identify;
+Amplitude.prototype.group = group;
 
 /**
  * Track an event, screen, or page call.
@@ -57,6 +58,28 @@ function track(payload, fn){
  */
 
 function identify(payload, fn) {
+  var self = this;
+  return this
+    .get('/identify')
+    .type('json')
+    .query({ api_key: this.settings.apiKey })
+    .query({ identification: JSON.stringify(payload) })
+    .end(this.handle(function(err, res){
+      if (err) return fn(err, res);
+      if ('invalid api_key' == res.text) return fn(self.error('invalid api_key'));
+      fn(null, res);
+    }));
+}
+
+/**
+ * Set groups via an identify call.
+ *
+ * @param {Facade} facade
+ * @param {Object} settings
+ * @param {Function} fn
+ */
+
+ function group(payload, fn) {
   var self = this;
   return this
     .get('/identify')

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -216,3 +216,27 @@ function traits(traits){
   del(traits, 'address');
   return traits;
 }
+
+/**
+ * Map `group`.
+ *
+ * @param {Group} group
+ * @return {Object} payload
+ */
+
+exports.group = function(group){
+  var groupId = group.groupId();
+  if (!groupId) return;
+  var payload = {
+    user_id: group.userId(),
+    device_id: deviceId(group),
+    time: group.timestamp().getTime(),
+    groups: {
+      '[Segment] Group': groupId
+    },
+    user_properties: {
+      '[Segment] Group': groupId
+    }
+  }
+  return payload;
+};

--- a/test/fixtures/group-basic.json
+++ b/test/fixtures/group-basic.json
@@ -1,0 +1,29 @@
+{
+  "input": {
+    "type": "group",
+    "groupId": "0e8c78ea9d97a7b8185e8632",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 19.99,
+      "property": true
+    },
+    "traits": {
+      "address": {
+        "country": "some-country"
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "user_properties": {
+      "[Segment] Group": "0e8c78ea9d97a7b8185e8632"
+    },
+    "groups": {
+      "[Segment] Group": "0e8c78ea9d97a7b8185e8632"
+    }
+  }
+}
+

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,12 @@ describe('Amplitude', function(){
       });
     });
 
+    describe('group', function(){
+      it('should map groupId', function(){
+        test.maps('group-basic');
+      });
+    });
+
     it('should remove `event_id`, `revenue`, `language` and `amplitude_event_type` from properties', function(){
       test.maps('clean');
     });
@@ -255,6 +261,18 @@ describe('Amplitude', function(){
         .set({ apiKey: 'foo' })
         .identify(json.input)
         .error(done);
+    });
+  });
+
+  describe('.group()', function(){
+    it('should map group calls correctly', function(done){
+      var json = test.fixture('group-basic');
+      test
+        .set(settings)
+        .group(json.input)
+        .query('api_key', settings.apiKey)
+        .query('identification', json.output, JSON.parse)
+        .expects(200, done);
     });
   });
 });


### PR DESCRIPTION
We can now set group via Amplitude's Identify API. Added new mapping to server-side integration