### PR TITLE
Parse additional revenue fields

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -20,6 +20,25 @@ var del = find.del;
 exports.track = function(track){
   var payload = common(track);
   payload.revenue = track.revenue();
+
+  // only set price and quantity if both exist
+  var price = track.price();
+  var quantity = track.quantity();
+  if (price && quantity) {
+    payload.price = price;
+    payload.quantity = quantity;
+  }
+
+  // additional revenue fields
+  var revenueType = track.proxy('properties.revenueType');
+  if (revenueType) {
+    payload.revenueType = revenueType;
+  }
+  var productId = track.proxy('properties.productId');
+  if (productId) {
+    payload.productId = productId;
+  }
+
   payload.event_type = track.event();
   payload.event_properties = properties(track.properties());
   return payload;
@@ -202,6 +221,10 @@ function properties(properties){
   del(properties, 'revenue');
   del(properties, 'event_id');
   del(properties, 'amplitude_event_type');
+  del(properties, 'price');
+  del(properties, 'quantity');
+  del(properties, 'productId');
+  del(properties, 'revenueType');
   return properties;
 }
 

--- a/test/fixtures/track-basic-revenue.json
+++ b/test/fixtures/track-basic-revenue.json
@@ -1,0 +1,41 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "revenue": 20.50,
+      "price": 10.25,
+      "quantity": 2,
+      "productId": "com.product.id",
+      "revenueType": "purchase",
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "revenue": 20.50,
+    "price": 10.25,
+    "quantity": 2,
+    "productId": "com.product.id",
+    "revenueType": "purchase",
+    "time": 1388534400000,
+    "event_type": "my-event",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/track-full-revenue.json
+++ b/test/fixtures/track-full-revenue.json
@@ -1,0 +1,79 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "country": "United States",
+      "revenue": 20.50,
+      "price": 10.25,
+      "quantity": 2,
+      "productId": "com.product.id",
+      "revenueType": "purchase",
+      "property": true
+    },
+    "context": {
+      "device": {
+        "id": "device-id",
+        "model": "device-model",
+        "brand": "device-brand",
+        "manufacturer": "device-manufacturer"
+      },
+      "locale": "en-US",
+      "library": { "name": "analytics.js" },
+      "app": { "version": "app-version" },
+      "os": {
+        "name": "os-name",
+        "version": "os-version"
+      },
+      "network": { "carrier": "carrier" },
+      "ip": "0.0.0.0",
+      "location": {
+        "latitude": 1.0,
+        "longitude": 1.0
+      }
+    },
+    "integrations": {
+      "Amplitude": {
+        "eventType": "amplitude-event-type",
+        "sessionId": 1,
+        "eventId": 1
+      }
+    }
+  },
+  "output": {
+    "amplitude_event_type": "amplitude-event-type",
+    "session_id": 1,
+    "event_id": 1,
+    "app_version": "app-version",
+    "platform": "Web",
+    "os_name": "os-name",
+    "os_version": "os-version",
+    "device_brand": "device-brand",
+    "carrier": "carrier",
+    "device_id": "device-id",
+    "device_manufacturer": "device-manufacturer",
+    "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
+    "location_lat": 1.0,
+    "location_lng": 1.0,
+    "device_model": "device-model",
+    "user_id": "user-id",
+    "revenue": 20.50,
+    "price": 10.25,
+    "quantity": 2,
+    "productId": "com.product.id",
+    "revenueType": "purchase",
+    "time": 1388534400000,
+    "event_type": "my-event",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -217,6 +217,28 @@ describe('Amplitude', function(){
         .query('event', json.output, JSON.parse)
         .expects(200, done);
     });
+
+    it('should track basic revenue fields', function(done){
+      var json = test.fixture('track-basic-revenue');
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query('api_key', settings.apiKey)
+        .query('event', json.output, JSON.parse)
+        .expects(200, done);
+    });
+
+    it('should track full revenue fields', function(done){
+      var json = test.fixture('track-full-revenue');
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query('api_key', settings.apiKey)
+        .query('event', json.output, JSON.parse)
+        .expects(200, done);
+    });
   });
 
   describe('.identify()', function(){


### PR DESCRIPTION
This mirrors the 3 recent updates to our other integrations (iOS, Android, JS), making some additional revenue fields available to users. Adding top level `price` and `quantity` (although both have to be defined in order to be set). Adding top level `productId` and `revenueType` fields as well. Added some additional tests.