### PR TITLE
Only send revenue properties when event has revenue

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -19,28 +19,32 @@ var del = find.del;
 
 exports.track = function(track){
   var payload = common(track);
-  payload.revenue = track.revenue();
+  var revenue = track.revenue();
+  payload.revenue = revenue;
 
-  // only set price and quantity if both exist
-  var price = track.price();
-  var quantity = track.quantity();
-  if (price && quantity) {
-    payload.price = price;
-    payload.quantity = quantity;
-  }
+  // only track revenue properties if logging revenue
+  if (revenue) {
+    // only set price and quantity if both exist
+    var price = track.price();
+    var quantity = track.quantity();
+    if (price && quantity) {
+      payload.price = price;
+      payload.quantity = quantity;
+    }
 
-  // additional revenue fields
-  var revenueType = track.proxy('properties.revenueType');
-  if (revenueType) {
-    payload.revenueType = revenueType;
-  }
-  var productId = track.proxy('properties.productId');
-  if (productId) {
-    payload.productId = productId;
+    // additional revenue fields
+    var revenueType = track.proxy('properties.revenueType');
+    if (revenueType) {
+      payload.revenueType = revenueType;
+    }
+    var productId = track.proxy('properties.productId');
+    if (productId) {
+      payload.productId = productId;
+    }
   }
 
   payload.event_type = track.event();
-  payload.event_properties = properties(track.properties());
+  payload.event_properties = properties(track.properties(), revenue);
   return payload;
 };
 
@@ -215,16 +219,20 @@ function locale(facade){
  * @return {Object}
  */
 
-function properties(properties){
+function properties(properties, hasRevenue){
   del(properties, 'country');
   del(properties, 'language');
   del(properties, 'revenue');
   del(properties, 'event_id');
   del(properties, 'amplitude_event_type');
-  del(properties, 'price');
-  del(properties, 'quantity');
-  del(properties, 'productId');
-  del(properties, 'revenueType');
+
+  // only delete revenue properties if there is revenue
+  if (hasRevenue) {
+    del(properties, 'price');
+    del(properties, 'quantity');
+    del(properties, 'productId');
+    del(properties, 'revenueType');
+  }
   return properties;
 }
 

--- a/test/fixtures/track-basic-no-revenue.json
+++ b/test/fixtures/track-basic-no-revenue.json
@@ -1,0 +1,39 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "price": 10.25,
+      "quantity": 2,
+      "productId": "com.product.id",
+      "revenueType": "purchase",
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "my-event",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "price": 10.25,
+      "quantity": 2,
+      "productId": "com.product.id",
+      "revenueType": "purchase",
+      "property": true
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -239,6 +239,17 @@ describe('Amplitude', function(){
         .query('event', json.output, JSON.parse)
         .expects(200, done);
     });
+
+    it('should not track revenue properties if there is no revenue', function(done){
+      var json = test.fixture('track-basic-no-revenue');
+
+      test
+        .set(settings)
+        .track(json.input)
+        .query('api_key', settings.apiKey)
+        .query('event', json.output, JSON.parse)
+        .expects(200, done);
+    });
   });
 
   describe('.identify()', function(){


### PR DESCRIPTION
https://github.com/segment-integrations/integration-amplitude/pull/19 introduced some unexpected behavior for a few of our customers. I added parsing of quantity and price to send on the event, and they get treated as revenue. However, there are many cases where customers will track quantity and price for an event, but not expect it to be treated as revenue, for example looking at a specific item in their online store. This was causing inflated revenue for many of our customers.

The proper way is just to parse out price and quantity if revenue is on the event. Please release this ASAP @f2prateek @hankim813 thanks!