### PR TITLE
Modify page and screen calls to respect track*Pages settings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@
 
 var integration = require('segmentio-integration');
 var mapper = require('./mapper');
+var some = require('lodash.some');
 
 /**
  * Expose `Amplitude`
@@ -21,8 +22,8 @@ var Amplitude = module.exports = integration('Amplitude')
  * Set up our prototype methods
  */
 
-Amplitude.prototype.page = track;
-Amplitude.prototype.screen = track;
+Amplitude.prototype.page = page;
+Amplitude.prototype.screen = page;
 Amplitude.prototype.track = track;
 Amplitude.prototype.identify = identify;
 Amplitude.prototype.group = group;
@@ -30,12 +31,46 @@ Amplitude.prototype.group = group;
 /**
  * Track an event, screen, or page call.
  *
- * @param {Facade} facade
- * @param {Object} settings
+ * @param {Object} payload
  * @param {Function} fn
  */
-
 function track(payload, fn){
+  var self = this;
+  return this
+    .get('/httpapi')
+    .type('json')
+    .query({ api_key: this.settings.apiKey })
+    .query({ event: JSON.stringify(payload) })
+    .end(this.handle(function(err, res){
+      if (err) return fn(err, res);
+      if ('invalid api_key' == res.text) return fn(self.error('invalid api_key'));
+      fn(null, res);
+    }));
+}
+
+/**
+ * Track a screen or page call.
+ *
+ * @param {Object} payload
+ * @param {Function} fn
+ */
+function page(payload, fn){
+  // Amplitude is generally not used for page tracking so we offer options to
+  // filter out irrelevant page calls.
+  //
+  // If track all pages is enabled, let the page call through.
+  // If trackCategorizedPages or trackNamedPages (or both) is enabled, check to
+  // be sure the event has the necessary category or name properties and send it
+  // through if it does; otherwise, drop the event
+  var shouldTrack = this.settings.trackAllPages || some([
+    this.settings.trackCategorizedPages && payload.event_properties.category,
+    this.settings.trackNamedPages && payload.event_properties.name
+  ]);
+
+  if (!shouldTrack) {
+    return fn();
+  }
+
   var self = this;
   return this
     .get('/httpapi')
@@ -52,11 +87,9 @@ function track(payload, fn){
 /**
  * Send an identify call.
  *
- * @param {Facade} facade
- * @param {Object} settings
+ * @param {Object} payload
  * @param {Function} fn
  */
-
 function identify(payload, fn) {
   var self = this;
   return this
@@ -74,11 +107,9 @@ function identify(payload, fn) {
 /**
  * Set groups via an identify call.
  *
- * @param {Facade} facade
- * @param {Object} settings
+ * @param {Object} payload
  * @param {Function} fn
  */
-
  function group(payload, fn) {
   var self = this;
   return this

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "locale-string": "^1.0.0",
+    "lodash.some": "^4.6.0",
     "obj-case": "^0.1.1",
     "reject": "0.0.1",
     "segmentio-integration": "^5.0.0",

--- a/test/fixtures/page-category.json
+++ b/test/fixtures/page-category.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Hello",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded a Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "category": "Hello",
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/page-name.json
+++ b/test/fixtures/page-name.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Hello World",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Viewed Hello World Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "name": "Hello World",
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/page-no-category.json
+++ b/test/fixtures/page-no-category.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded a Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/page-no-name.json
+++ b/test/fixtures/page-no-name.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Viewed a Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/screen-category.json
+++ b/test/fixtures/screen-category.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded Docs Screen",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "category": "Docs",
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/screen-name.json
+++ b/test/fixtures/screen-name.json
@@ -1,0 +1,32 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Hello World",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded Hello World Screen",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "name": "Hello World",
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/screen-no-category.json
+++ b/test/fixtures/screen-no-category.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded a Screen",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/fixtures/screen-no-name.json
+++ b/test/fixtures/screen-no-name.json
@@ -1,0 +1,30 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {
+      "property": true
+    },
+    "context": {
+      "traits": {
+        "address": {
+          "country": "some-country"
+        }
+      }
+    }
+  },
+  "output": {
+    "country": "some-country",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Loaded a Screen",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_properties": {
+      "property": true
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,12 @@ describe('Amplitude', function(){
   var test;
 
   beforeEach(function(){
-    settings = { apiKey: 'ad3c426eb736d7442a65da8174bc1b1b' };
+    settings = {
+      apiKey: 'ad3c426eb736d7442a65da8174bc1b1b',
+      trackAllPages: true,
+      trackCategorizedPages: false,
+      trackNamedPages: false
+    };
     amplitude = new Amplitude(settings);
     test = Test(amplitude, __dirname);
   });
@@ -91,6 +96,7 @@ describe('Amplitude', function(){
 
   describe('.page()', function(){
     it('should map page calls correctly', function(done){
+      settings.trackAllPages = true;
       var json = test.fixture('page-basic');
       test
         .set(settings)
@@ -101,15 +107,121 @@ describe('Amplitude', function(){
     });
 
     it('should record page calls with bad fields correctly', function(done){
+      settings.trackAllPages = true;
       amplitude.page(helpers.page(), done);
     });
 
     it('should error on invalid creds', function(done){
+      settings.trackAllPages = true;
       var json = test.fixture('page-basic');
       test
         .set({ apiKey: 'foo' })
         .page(json.input)
         .error(done);
+    });
+
+    it('should send page when `settings.trackAllPages` is `true`', function(done) {
+      settings.trackAllPages = true;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-basic');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(1)
+        .expects(200, done);
+    });
+
+    it('should not send page when `settings.trackAllPages` is `false`', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-basic');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should send page when `settings.trackCategorizedPages` is `true` and `.category` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = true;
+      var json = test.fixture('page-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(1)
+        .end(done);
+    });
+
+    it('should not send page when `settings.trackCategorizedPages` is `true` and `.category` is missing', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = true;
+      var json = test.fixture('page-no-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should not send page when `settings.trackCategorizedPages` is `false` and `.category` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should send page when `settings.trackNamedPages` is `true` and `.name` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = true;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(1)
+        .end(done);
+    });
+
+    it('should not send page when `settings.trackNamedPages` is `true` and `.name` is missing', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = true;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-no-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should not send page when `settings.trackNamedPages` is `false` and `.name` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .page(json.input)
+        .requests(0)
+        .end(done);
     });
   });
 
@@ -134,6 +246,110 @@ describe('Amplitude', function(){
         .set({ apiKey: 'foo' })
         .screen(json.input)
         .error(done);
+    });
+
+    it('should send screen when `settings.trackAllPages` is `true`', function(done) {
+      settings.trackAllPages = true;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-basic');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(1)
+        .expects(200, done);
+    });
+
+    it('should not send screen when `settings.trackAllPages` is `false`', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-basic');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should send screen when `settings.trackCategorizedPages` is `true` and `.category` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = true;
+      var json = test.fixture('screen-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(1)
+        .end(done);
+    });
+
+    it('should not send screen when `settings.trackCategorizedPages` is `true` and `.category` is missing', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = true;
+      var json = test.fixture('screen-no-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should not send screen when `settings.trackCategorizedPages` is `false` and `.category` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-category');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should send screen when `settings.trackNamedPages` is `true` and `.name` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = true;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(1)
+        .end(done);
+    });
+
+    it('should not send screen when `settings.trackNamedPages` is `true` and `.name` is missing', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = true;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-no-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(0)
+        .end(done);
+    });
+
+    it('should not send screen when `settings.trackNamedPages` is `false` and `.name` is present', function(done) {
+      settings.trackAllPages = false;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-name');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
+        .requests(0)
+        .end(done);
     });
   });
 


### PR DESCRIPTION
Right now our client-side Amplitude integration respects
`trackAllPages`, `trackCategorizedPages`, and `trackNamedPages`, which
turn page tracking on or off under different scenarios. Most of our
server-side integrations mirror this behavior, but Amplitude did not.

This update updates Amplitude to mirror the client-side integration.