### PR TITLE
add revenue also under event_properties for parity

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+3.1.0 / 2016-12-13
+==================
+
+  * Send revenue also nested under event_properties for client side parity
+
 3.0.2 / 2016-11-29
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -232,7 +232,6 @@ function locale(facade){
 function properties(properties, hasRevenue){
   del(properties, 'country');
   del(properties, 'language');
-  del(properties, 'revenue');
   del(properties, 'event_id');
   del(properties, 'amplitude_event_type');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-amplitude",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "integration-version": "2016-09-16",
   "private": true,
   "description": "Amplitude server-side integration",

--- a/test/fixtures/clean.json
+++ b/test/fixtures/clean.json
@@ -5,7 +5,6 @@
     "event": "my-event",
     "timestamp": "2014",
     "properties": {
-      "revenue": 19.99,
       "property": true,
       "language": "language",
       "event_id": "event-id",
@@ -14,7 +13,6 @@
   },
   "output": {
     "user_id": "user-id",
-    "revenue": 19.99,
     "time": 1388534400000,
     "event_type": "my-event",
     "library": "segment",

--- a/test/fixtures/page-full.json
+++ b/test/fixtures/page-full.json
@@ -7,7 +7,6 @@
     "category": "Docs",
     "properties": {
       "country": "United States",
-      "revenue": 19.99,
       "property": true
     },
     "context": {

--- a/test/fixtures/screen-full.json
+++ b/test/fixtures/screen-full.json
@@ -7,7 +7,6 @@
     "category": "Docs",
     "properties": {
       "country": "United States",
-      "revenue": 19.99,
       "property": true
     },
     "context": {

--- a/test/fixtures/track-adid-android.json
+++ b/test/fixtures/track-adid-android.json
@@ -67,6 +67,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 19.99,
       "property": true
     }
   }

--- a/test/fixtures/track-analytics-php.json
+++ b/test/fixtures/track-analytics-php.json
@@ -6,7 +6,6 @@
     "timestamp": "2014",
     "properties": {
       "country": "United States",
-      "revenue": 19.99,
       "property": true
     },
     "context": {
@@ -55,7 +54,6 @@
     "location_lng": 1.0,
     "device_model": "device-model",
     "user_id": "user-id",
-    "revenue": 19.99,
     "time": 1388534400000,
     "event_type": "my-event",
     "library": "segment",

--- a/test/fixtures/track-analyticsjs.json
+++ b/test/fixtures/track-analyticsjs.json
@@ -66,6 +66,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 19.99,
       "property": true
     }
   }

--- a/test/fixtures/track-android.json
+++ b/test/fixtures/track-android.json
@@ -67,6 +67,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 19.99,
       "property": true
     }
   }

--- a/test/fixtures/track-bad.json
+++ b/test/fixtures/track-bad.json
@@ -6,7 +6,6 @@
     "timestamp": "2014",
     "properties": {
       "country": "United States",
-      "revenue": 19.99,
       "property": true
     },
     "context": {
@@ -58,7 +57,6 @@
     "location_lng": 1.0,
     "device_model": "device-model",
     "user_id": "user-id",
-    "revenue": 19.99,
     "time": 1388534400000,
     "event_type": "my-event",
     "library": "segment",

--- a/test/fixtures/track-basic-revenue.json
+++ b/test/fixtures/track-basic-revenue.json
@@ -35,6 +35,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 20.50,
       "property": true
     }
   }

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -5,7 +5,6 @@
     "event": "my-event",
     "timestamp": "2014",
     "properties": {
-      "revenue": 19.99,
       "property": true
     },
     "context": {
@@ -19,7 +18,6 @@
   "output": {
     "country": "some-country",
     "user_id": "user-id",
-    "revenue": 19.99,
     "time": 1388534400000,
     "event_type": "my-event",
     "library": "segment",

--- a/test/fixtures/track-full-revenue.json
+++ b/test/fixtures/track-full-revenue.json
@@ -73,6 +73,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 20.50,
       "property": true
     }
   }

--- a/test/fixtures/track-full.json
+++ b/test/fixtures/track-full.json
@@ -6,7 +6,6 @@
     "timestamp": "2014",
     "properties": {
       "country": "United States",
-      "revenue": 19.99,
       "property": true
     },
     "context": {
@@ -57,7 +56,6 @@
     "location_lng": 1.0,
     "device_model": "device-model",
     "user_id": "user-id",
-    "revenue": 19.99,
     "time": 1388534400000,
     "event_type": "my-event",
     "library": "segment",

--- a/test/fixtures/track-idfa-ios.json
+++ b/test/fixtures/track-idfa-ios.json
@@ -67,6 +67,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 19.99,
       "property": true
     }
   }

--- a/test/fixtures/track-ios.json
+++ b/test/fixtures/track-ios.json
@@ -67,6 +67,7 @@
       "id": "user-id"
     },
     "event_properties": {
+      "revenue": 19.99,
       "property": true
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ describe('Amplitude', function(){
       });
     });
 
-    it('should remove `event_id`, `revenue`, `language` and `amplitude_event_type` from properties', function(){
+    it('should remove `event_id`, `language` and `amplitude_event_type` from properties', function(){
       test.maps('clean');
     });
 


### PR DESCRIPTION
This is the server side component of this client side PR: https://github.com/segment-integrations/analytics.js-integration-amplitude/pull/25

Essentially, when we send `revenue` at the top level, Amplitude's servers will convert that to `$revenue`. This is why there is lack of parity when reporting when dissecting data from both ajs and server/mobile. By sending `revenue` under `event_properties` as well, both client and server will be aligned so that whether you want to peg reports based on `$revenue` or `revenue`, it will be the same. 

@djih could you confirm that sending `event_properties.revenue` will not be converted to $revenue and thus either double count/pollute the revenue value?

- [ ] deploy

@f2prateek @tsholmes 