### PR TITLE
Map search query params to custom property value under user or event properties EPD-2483

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+4.2.0 / 2017-04-07
+==================
+
+  * Add option to map custom prop under user or event properties to send query params
+
 4.1.0 / 2017-03-08
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -9,17 +9,21 @@ var parse = require('locale-string').parse;
 var reject = require('reject');
 var title = require('to-title-case');
 var UAParser = require('ua-parser-js');
+var isEmpty = require('lodash/isEmpty');
+var values = require('lodash/values');
+var keys = require('lodash/keys');
 
 /**
  * Map `track`.
  *
  * @param {Track} track
+ * @param {Object} settings
  * @return {Object}
  * @api private
  */
 
-exports.track = function(track){
-  var payload = common(track);
+exports.track = function(track, settings){
+  var payload = common(track, settings);
   var revenue = track.revenue();
   payload.revenue = revenue;
 
@@ -53,12 +57,13 @@ exports.track = function(track){
  * Map `page`.
  *
  * @param {Page} page
+ * @param {Object} settings
  * @return {Object}
  * @api private
  */
 
-exports.page = function(page){
-  var payload = common(page);
+exports.page = function(page, settings){
+  var payload = common(page, settings);
   payload.event_type = page.event(page.fullName());
   payload.event_properties = properties(page.properties());
   return payload;
@@ -68,12 +73,13 @@ exports.page = function(page){
  * Map `screen`.
  *
  * @param {Screen} screen
+ * @param {Object} settings
  * @return {Object}
  * @api private
  */
 
-exports.screen = function(screen){
-  var payload = common(screen);
+exports.screen = function(screen, settings){
+  var payload = common(screen, settings);
   payload.event_type = screen.event(screen.fullName());
   payload.event_properties = properties(screen.properties());
   return payload;
@@ -83,11 +89,12 @@ exports.screen = function(screen){
  * Map `identify`.
  *
  * @param {Identify} identify
+ * @param {Object} settings
  * @return {Object} payload
  */
 
-exports.identify = function(identify){
-  var payload = common(identify);
+exports.identify = function(identify, settings){
+  var payload = common(identify, settings);
   del(payload, 'amplitude_event_type');
   del(payload, 'session_id');
   del(payload, 'event_id');
@@ -111,10 +118,11 @@ function deviceId(facade) {
  * Format the amplitude specific properties.
  *
  * @param {Track} facade
+ * @param {Object} settings
  * @return {Object}
  */
 
-function common(facade){
+function common(facade, settings){
   var options = facade.options('Amplitude');
   var os = facade.proxy('context.os.name');
   var ret = {
@@ -171,6 +179,18 @@ function common(facade){
   }
 
   ret.user_properties = traits(facade.traits());
+
+  // map query params from context url if opted in
+  var mapQueryParams = settings.mapQueryParams || {};
+  if (!isEmpty(mapQueryParams)) {
+    // since we accept any arbitrary property name and we dont have conditional UI components
+    // in the app so excuse the jank
+    var property = keys(mapQueryParams)[0];
+    // add query params to either `user_properties` or `event_properties`
+    // aliased under arbitrary custom prop provided in settings
+    var type = values(mapQueryParams)[0] || 'user_properties';
+    ret[type][property] = facade.proxy('context.page.search');
+  }
 
   return reject(ret);
 }

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -12,6 +12,7 @@ var UAParser = require('ua-parser-js');
 var isEmpty = require('lodash/isEmpty');
 var values = require('lodash/values');
 var keys = require('lodash/keys');
+var extend = require('extend');
 
 /**
  * Map `track`.
@@ -49,7 +50,7 @@ exports.track = function(track, settings){
   }
 
   payload.event_type = track.event();
-  payload.event_properties = properties(track.properties(), revenue);
+  payload.event_properties = extend(payload.event_properties, properties(track.properties(), revenue));
   return payload;
 };
 
@@ -65,7 +66,7 @@ exports.track = function(track, settings){
 exports.page = function(page, settings){
   var payload = common(page, settings);
   payload.event_type = page.event(page.fullName());
-  payload.event_properties = properties(page.properties());
+  payload.event_properties = extend(payload.event_properties, properties(page.properties()));
   return payload;
 };
 
@@ -81,7 +82,7 @@ exports.page = function(page, settings){
 exports.screen = function(screen, settings){
   var payload = common(screen, settings);
   payload.event_type = screen.event(screen.fullName());
-  payload.event_properties = properties(screen.properties());
+  payload.event_properties = extend(payload.event_properties, properties(screen.properties()));
   return payload;
 };
 
@@ -189,7 +190,14 @@ function common(facade, settings){
     // add query params to either `user_properties` or `event_properties`
     // aliased under arbitrary custom prop provided in settings
     var type = values(mapQueryParams)[0] || 'user_properties';
-    ret[type][property] = facade.proxy('context.page.search');
+    // `.identify()` calls can't set event_properties
+    var query = facade.proxy('context.page.search');
+    if (facade.type() === 'identify') {
+      ret.user_properties[property] = query;
+    } else {
+      ret.event_properties = {};
+      ret.event_properties[property] = query;
+    }
   }
 
   return reject(ret);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-amplitude",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Amplitude server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "locale-string": "^1.0.0",
+    "lodash": "^4.17.4",
     "lodash.some": "^4.6.0",
     "obj-case": "^0.1.1",
     "reject": "0.0.1",
@@ -36,7 +37,7 @@
     "obj-case": "^0.1.1",
     "reject": "0.0.1",
     "segmentio-facade": "2.x",
-    "segmentio-integration-tester": "1.x",
+    "segmentio-integration-tester": "2.x",
     "should": "4.x",
     "to-title-case": "^0.1.5",
     "uid": "0.0.2",

--- a/test/fixtures/identify-query-params.json
+++ b/test/fixtures/identify-query-params.json
@@ -1,21 +1,10 @@
 {
   "input": {
-    "type": "track",
+    "type": "identify",
     "userId": "user-id",
     "event": "my-event",
     "timestamp": "2014",
-    "properties": {
-      "country": "United States",
-      "property": true
-    },
     "context": {
-      "page": {
-        "path": "/academy/",
-        "referrer": "",
-        "search": "?suh=dude&yo=man",
-        "title": "Analytics Academy",
-        "url": "https://segment.com/academy/"
-      },
       "device": {
         "id": "device-id",
         "model": "device-model",
@@ -23,7 +12,14 @@
         "manufacturer": "device-manufacturer"
       },
       "locale": "en-US",
-      "library": { "name": "analytics.js" },
+      "page": {
+        "path": "/academy/",
+        "referrer": "",
+        "search": "?foo=bar",
+        "title": "Analytics Academy",
+        "url": "https://segment.com/academy/"
+      },
+      "library": { "name": "analytics-ios" },
       "app": { "version": "app-version" },
       "os": {
         "name": "os-name",
@@ -34,6 +30,11 @@
       "location": {
         "latitude": 1.0,
         "longitude": 1.0
+      }
+    },
+    "traits": {
+      "address": {
+        "country": "United States"
       }
     },
     "integrations": {
@@ -59,19 +60,12 @@
     "location_lat": 1.0,
     "location_lng": 1.0,
     "ip": "0.0.0.0",
-    "amplitude_event_type": "amplitude-event-type",
-    "session_id": 1,
-    "event_id": 1,
     "language": "English",
     "country": "United States",
-    "platform": "Web",
+    "platform": "iOS",
     "user_properties": {
-      "id": "user-id"
-    },
-    "event_properties": {
-      "search": "?suh=dude&yo=man",
-      "property": true
-    },
-    "event_type": "my-event"
+      "id": "user-id",
+      "search": "?foo=bar"
+    }
   }
 }

--- a/test/fixtures/page-query-params.json
+++ b/test/fixtures/page-query-params.json
@@ -1,0 +1,70 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Analytics iOS",
+    "category": "Docs",
+    "properties": {
+      "country": "United States",
+      "property": true
+    },
+    "context": {
+      "page": {
+        "path": "/academy/",
+        "referrer": "",
+        "search": "?suh=hello&dude=yo",
+        "title": "Analytics Academy",
+        "url": "https://segment.com/academy/"
+      },
+      "device": {
+        "id": "device-id",
+        "model": "device-model",
+        "brand": "device-brand",
+        "manufacturer": "device-manufacturer"
+      },
+      "locale": "en-US",
+      "library": { "name": "analytics-ios" },
+      "app": { "version": "app-version" },
+      "os": {
+        "name": "os-name",
+        "version": "os-version"
+      },
+      "network": { "carrier": "carrier" },
+      "ip": "0.0.0.0",
+      "location": {
+        "latitude": 40.2964197,
+        "longitude": -76.9411617
+      }
+    }
+  },
+  "output": {
+    "app_version": "app-version",
+    "platform": "iOS",
+    "os_name": "os-name",
+    "os_version": "os-version",
+    "device_brand": "device-brand",
+    "carrier": "carrier",
+    "device_id": "device-id",
+    "device_manufacturer": "device-manufacturer",
+    "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
+    "latitude": 40.2964197,
+    "longitude": -76.9411617,
+    "device_model": "device-model",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Viewed Docs Analytics iOS Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id",
+      "search": "?suh=hello&dude=yo"
+    },
+    "event_properties": {
+      "property": true,
+      "category": "Docs",
+      "name": "Analytics iOS"
+    }
+  }
+}

--- a/test/fixtures/screen-query-params.json
+++ b/test/fixtures/screen-query-params.json
@@ -1,0 +1,70 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "name": "Analytics iOS",
+    "category": "Docs",
+    "properties": {
+      "country": "United States",
+      "property": true
+    },
+    "context": {
+      "page": {
+        "path": "/academy/",
+        "referrer": "",
+        "search": "?suh=hello&dude=yo",
+        "title": "Analytics Academy",
+        "url": "https://segment.com/academy/"
+      },
+      "device": {
+        "id": "device-id",
+        "model": "device-model",
+        "brand": "device-brand",
+        "manufacturer": "device-manufacturer"
+      },
+      "locale": "en-US",
+      "library": { "name": "analytics-ios" },
+      "app": { "version": "app-version" },
+      "os": {
+        "name": "os-name",
+        "version": "os-version"
+      },
+      "network": { "carrier": "carrier" },
+      "ip": "0.0.0.0",
+      "location": {
+        "latitude": 40.2964197,
+        "longitude": -76.9411617
+      }
+    }
+  },
+  "output": {
+    "app_version": "app-version",
+    "platform": "iOS",
+    "os_name": "os-name",
+    "os_version": "os-version",
+    "device_brand": "device-brand",
+    "carrier": "carrier",
+    "device_id": "device-id",
+    "device_manufacturer": "device-manufacturer",
+    "ip": "0.0.0.0",
+    "language": "English",
+    "country": "United States",
+    "latitude": 40.2964197,
+    "longitude": -76.9411617,
+    "device_model": "device-model",
+    "user_id": "user-id",
+    "time": 1388534400000,
+    "event_type": "Viewed Docs Analytics iOS Page",
+    "library": "segment",
+    "user_properties": {
+      "id": "user-id",
+      "search": "?suh=hello&dude=yo"
+    },
+    "event_properties": {
+      "property": true,
+      "category": "Docs",
+      "name": "Analytics iOS"
+    }
+  }
+}

--- a/test/fixtures/track-query-params.json
+++ b/test/fixtures/track-query-params.json
@@ -1,0 +1,77 @@
+{
+  "input": {
+    "type": "track",
+    "userId": "user-id",
+    "event": "my-event",
+    "timestamp": "2014",
+    "properties": {
+      "country": "United States",
+      "property": true
+    },
+    "context": {
+      "page": {
+        "path": "/academy/",
+        "referrer": "",
+        "search": "?suh=dude&yo=man",
+        "title": "Analytics Academy",
+        "url": "https://segment.com/academy/"
+      },
+      "device": {
+        "id": "device-id",
+        "model": "device-model",
+        "brand": "device-brand",
+        "manufacturer": "device-manufacturer"
+      },
+      "locale": "en-US",
+      "library": { "name": "analytics.js" },
+      "app": { "version": "app-version" },
+      "os": {
+        "name": "os-name",
+        "version": "os-version"
+      },
+      "network": { "carrier": "carrier" },
+      "ip": "0.0.0.0",
+      "location": {
+        "latitude": 1.0,
+        "longitude": 1.0
+      }
+    },
+    "integrations": {
+      "Amplitude": {
+        "eventType": "amplitude-event-type",
+        "sessionId": 1,
+        "eventId": 1
+      }
+    }
+  },
+  "output": {
+    "user_id": "user-id",
+    "device_id": "device-id",
+    "time": 1388534400000,
+    "library": "segment",
+    "app_version": "app-version",
+    "os_name": "os-name",
+    "os_version": "os-version",
+    "carrier": "carrier",
+    "device_model": "device-model",
+    "device_brand": "device-brand",
+    "device_manufacturer": "device-manufacturer",
+    "location_lat": 1.0,
+    "location_lng": 1.0,
+    "ip": "0.0.0.0",
+    "amplitude_event_type": "amplitude-event-type",
+    "session_id": 1,
+    "event_id": 1,
+    "language": "English",
+    "country": "United States",
+    "platform": "Web",
+    "user_properties": {
+      "id": "user-id"
+    },
+    "event_type": "my-event",
+    "event_properties": {
+      "property": true,
+      "search": "?suh=dude&yo=man"
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,10 @@ describe('Amplitude', function(){
       apiKey: 'ad3c426eb736d7442a65da8174bc1b1b',
       trackAllPages: true,
       trackCategorizedPages: false,
-      trackNamedPages: false
+      trackNamedPages: false,
+      mapQueryParams: {
+        'search': 'user_properties'
+      }
     };
     amplitude = new Amplitude(settings);
     test = Test(amplitude, __dirname);
@@ -121,6 +124,7 @@ describe('Amplitude', function(){
         .error(done);
     });
 
+
     it('should send page when `settings.trackAllPages` is `true`', function(done) {
       settings.trackAllPages = true;
       settings.trackNamedPages = false;
@@ -131,6 +135,18 @@ describe('Amplitude', function(){
         .set({ apiKey: settings.apiKey })
         .page(json.input)
         .requests(1)
+        .expects(200, done);
+    });
+
+    it('should send page with query params when `settings.mapQueryParams` is set', function(done) {
+      settings.trackAllPages = true;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('page-query-params');
+
+      test
+        .set(settings)
+        .page(json.input)
         .expects(200, done);
     });
 
@@ -156,7 +172,6 @@ describe('Amplitude', function(){
       test
         .set({ apiKey: settings.apiKey })
         .page(json.input)
-        .requests(1)
         .end(done);
     });
 
@@ -195,7 +210,6 @@ describe('Amplitude', function(){
       test
         .set({ apiKey: settings.apiKey })
         .page(json.input)
-        .requests(1)
         .end(done);
     });
 
@@ -258,7 +272,18 @@ describe('Amplitude', function(){
       test
         .set({ apiKey: settings.apiKey })
         .screen(json.input)
-        .requests(1)
+        .expects(200, done);
+    });
+
+    it('should send screen with query params when `settings.mapQueryParams` is set', function(done) {
+      settings.trackAllPages = true;
+      settings.trackNamedPages = false;
+      settings.trackCategorizedPages = false;
+      var json = test.fixture('screen-query-params');
+
+      test
+        .set({ apiKey: settings.apiKey })
+        .screen(json.input)
         .expects(200, done);
     });
 
@@ -357,6 +382,16 @@ describe('Amplitude', function(){
   describe('.track()', function(){
     it('should map track calls correctly', function(done){
       var json = test.fixture('track-basic');
+      test
+        .track(json.input)
+        .sends('api_key=' + settings.apiKey + '&event=' + encode(JSON.stringify(json.output)))
+        .expects(200)
+        .end(done);
+    });
+
+    it('should map track calls correctly with query params if set', function(done){
+      var json = test.fixture('track-query-params');
+      settings.mapQueryParams.search = 'event_properties'; // default is user_properties but that has bene tested already
       test
         .track(json.input)
         .sends('api_key=' + settings.apiKey + '&event=' + encode(JSON.stringify(json.output)))

--- a/test/index.js
+++ b/test/index.js
@@ -17,9 +17,7 @@ describe('Amplitude', function(){
       trackAllPages: true,
       trackCategorizedPages: false,
       trackNamedPages: false,
-      mapQueryParams: {
-        'search': 'user_properties'
-      }
+      mapQueryParams: {}
     };
     amplitude = new Amplitude(settings);
     test = Test(amplitude, __dirname);
@@ -142,6 +140,7 @@ describe('Amplitude', function(){
       settings.trackAllPages = true;
       settings.trackNamedPages = false;
       settings.trackCategorizedPages = false;
+      settings.mapQueryParams = { search: 'user_properties' }
       var json = test.fixture('page-query-params');
 
       test
@@ -279,6 +278,7 @@ describe('Amplitude', function(){
       settings.trackAllPages = true;
       settings.trackNamedPages = false;
       settings.trackCategorizedPages = false;
+      settings.mapQueryParams = { search: 'user_properties' }
       var json = test.fixture('screen-query-params');
 
       test
@@ -391,8 +391,10 @@ describe('Amplitude', function(){
 
     it('should map track calls correctly with query params if set', function(done){
       var json = test.fixture('track-query-params');
-      settings.mapQueryParams.search = 'event_properties'; // default is user_properties but that has bene tested already
+      settings.mapQueryParams = { search: 'event_properties' }; // default is user_properties but that has been tested already
+
       test
+        .set(settings)
         .track(json.input)
         .sends('api_key=' + settings.apiKey + '&event=' + encode(JSON.stringify(json.output)))
         .expects(200)
@@ -525,6 +527,19 @@ describe('Amplitude', function(){
     it('should map identify calls correctly', function(done){
       var json = test.fixture('identify-basic');
       test
+        .identify(json.input)
+        .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))
+        .expects(200)
+        .end(done);
+    });
+
+    it('should map query params as user_properties if settings are set', function(done){
+      var json = test.fixture('identify-query-params');
+
+      settings.mapQueryParams = { search: 'event_properties' }; // this should be overriden to user_properties
+
+      test
+        .set(settings)
         .identify(json.input)
         .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))
         .expects(200)


### PR DESCRIPTION
@tsholmes basically they want to be able to send all the `context.page.search` to a custom property on the `user_properties`. instead of making it one off -- im shipping this as a more flexible option so you can:

a) define what the name of the prop should be where you will map the query params
b) decide if you want to set it at user or event level.

I won't ever map to `event_properties` for `.identify()` calls though.

TODO: 

- [ ] mongo-script
- [ ] clientside pr
- [ ] site-docs
- [ ] deploy
- [ ] metadata