### PR TITLE
Identify with group

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+4.3.0 / 2017-05-17
+==================
+
+* Add support for Amplitude's `group` functionality
+
 4.2.1 / 2017-04-17
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -200,6 +200,13 @@ function common(facade, settings){
     }
   }
 
+  // Add groups.
+  var groups = options.groups;
+  if (groups) {
+    ret.groups = groups;
+    extend(ret.user_properties, groups);
+  }
+
   return reject(ret);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-amplitude",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Amplitude server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/identify-with-group.json
+++ b/test/fixtures/identify-with-group.json
@@ -1,0 +1,26 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "group-user-123",
+    "timestamp": "2016",
+    "integrations": {
+      "Amplitude": {
+        "groups": {
+          "foobar": ["basketball", "soccer"]
+        }
+      }
+    }
+  },
+  "output": {
+    "user_id": "group-user-123",
+    "time": 1451606400000,
+    "library": "segment",
+    "user_properties": {
+      "id": "group-user-123",
+      "foobar": ["basketball", "soccer"]
+    },
+    "groups": {
+      "foobar": ["basketball", "soccer"]
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -555,6 +555,16 @@ describe('Amplitude', function(){
         .end(done);
     });
 
+    it('should map identify with groups if `group` is an integration specific option', function(done){
+      var json = test.fixture('identify-with-group');
+
+      test
+        .identify(json.input)
+        .sends('api_key=' + settings.apiKey + '&identification=' + encode(JSON.stringify(json.output)))
+        .expects(200)
+        .end(done);
+    });
+
     it('it should generate a unique deviceId for android version 1.4.4', function(done){
       var json = test.fixture('identify-full');
       json.input.context.library.name = 'analytics-android';


### PR DESCRIPTION
PR adds support for Amplitude's `group` functionality.

Groups will be passed as an integration specific option. Amplitude specifies they be passed as a dictionary of key value pairs where the key is the groupType and the value is a string or array of strings representing the groupName(s).

We will mimic this specification but ask that the dictionary is passed as an integration specific option.

Groups can be set via both `track` and `identify` events so the logic has been added to the `common` function in `mapper`.

Groups are also set as `user_properties` which is the behavior of their JS library.

We're keeping our older `group` method for backwards compatibility but will be recommending that users use this new way of leveraging this functionality.